### PR TITLE
fix delimiting for fieldnames like 'userId'

### DIFF
--- a/src/Neevo/Parser.php
+++ b/src/Neevo/Parser.php
@@ -392,7 +392,7 @@ class Parser {
 	protected function tryDelimite($expr){
 		if($expr instanceof Literal)
 			return $expr->value;
-		return preg_replace_callback('~:([a-z_\*][a-z0-9._\*]*)~', array($this, 'parseFieldName'), $expr);
+		return preg_replace_callback('~:([a-z_\*][a-z0-9._\*]*)~i', array($this, 'parseFieldName'), $expr);
 	}
 
 


### PR DESCRIPTION
Mixed case fieldnames were delimited incorrectly.
eg: 'userId' would become user`Id`
